### PR TITLE
Avoid NPE if initialization of theJar failed silently in init().

### DIFF
--- a/src/main/java/org/codehaus/plexus/resource/loader/JarHolder.java
+++ b/src/main/java/org/codehaus/plexus/resource/loader/JarHolder.java
@@ -123,16 +123,19 @@ public class JarHolder
     {
         Hashtable allEntries = new Hashtable( 559 );
 
-        Enumeration all = theJar.entries();
-
-        while ( all.hasMoreElements() )
+        if ( theJar != null )
         {
-            JarEntry je = (JarEntry) all.nextElement();
+            Enumeration all = theJar.entries();
 
-            // We don't map plain directory entries
-            if ( !je.isDirectory() )
+            while ( all.hasMoreElements() )
             {
-                allEntries.put( je.getName(), this.urlpath );
+                JarEntry je = (JarEntry) all.nextElement();
+
+                // We don't map plain directory entries
+                if ( !je.isDirectory() )
+                {
+                    allEntries.put( je.getName(), this.urlpath );
+                }
             }
         }
         return allEntries;


### PR DESCRIPTION
Fixes NPE in maven-checkstyle-plugin, see [MCHECKSTYLE-250](http://jira.codehaus.org/browse/MCHECKSTYLE-250) and [MCHECKSTYLE-288](http://jira.codehaus.org/browse/MCHECKSTYLE-288).
